### PR TITLE
Moving package.json to root directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "description": "Provides JSONSchema-based RESTful web service abstraction.",
     "version": "1.0.0",
     "dojoBuild": "circuits.profile.js",
+    "files": ["src/main"],
     "dependencies": {
 	}
 }


### PR DESCRIPTION
Moved "package.json" file to root directory and added the "files" field to specify "src/main" as the directory to include in npm build.
