### PR TITLE
Fixed bug in resolveExtensions method ...

### DIFF
--- a/src/main/ZypSMDReader.js
+++ b/src/main/ZypSMDReader.js
@@ -97,7 +97,7 @@ define([
                 //unwind the property stack so that the earliest gets inheritance link
                 schema.properties = schema.properties || {};
                 function copyprop(item) { //util to get around jslint complaints about doing this directly in loop
-                    schema.properties[item.key] = item.val;
+                    schema.properties[item.key] = item.value;
                 }
 
                 while (xprops.length > 0) {


### PR DESCRIPTION
Fixed bug in resolveExtensions method that was causing the properties copied from an extended schema to be 'undefined'.
