### PR TITLE
9 make entire response object available in load callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ./r.js
 ./.idea
+/.project

--- a/src/main/ServiceMethod.js
+++ b/src/main/ServiceMethod.js
@@ -126,7 +126,8 @@ define([
                 }
 
                 newParams.request = provider[provider.httpMethodMap[method].method](requestParams);
-
+                newParams.response = that.reader.smd.services[that.name];
+                
                 if (smdReturn.type === "any") {
                     newParams.request.url = url;
                     newParams.request.mediaType = this.smdMethod.contentType || "";

--- a/src/main/ServiceMethod.js
+++ b/src/main/ServiceMethod.js
@@ -65,6 +65,8 @@ define([
 
                         //add the total from the payload if it is an array response. putting it in the request object, as that is where http status, etc. is stored.
                         newParams.request.total = data && data.total;
+                        
+                        newParams.response = data;
 
                         //links should be sitting alonside the actual payload, like the total.
                         newParams.links = data && data.links;
@@ -126,7 +128,7 @@ define([
                 }
 
                 newParams.request = provider[provider.httpMethodMap[method].method](requestParams);
-                newParams.response = that.reader.smd.services[that.name];
+              
                 
                 if (smdReturn.type === "any") {
                     newParams.request.url = url;

--- a/src/test/javascript/TestServiceMethod.js
+++ b/src/test/javascript/TestServiceMethod.js
@@ -98,6 +98,7 @@ require([
                                 assertEquals("90009528", data.caseNumber);
                                 assertUndefined(params.request.total); //single item response, should have undefined total
                                 assertEquals(2, params.links.length);
+                                assertEquals(singleResponse, params.response);
                             }
                         }]
                     });
@@ -145,6 +146,7 @@ require([
                                 assertEquals("1", data.caseNumber); //we've transformed the case number in the read processor
                                 assertTrue(data.justRead);
                                 assertUndefined(params.request.total); //single item response, should have undefined total
+                                assertEquals(singleResponse, params.response);
                             }
                         }
                     ]
@@ -169,6 +171,7 @@ require([
                                     assertEquals(10, params.request.total);
                                     assertEquals("90009528", data[0].caseNumber);
                                     assertEquals("90009529", data[1].caseNumber);
+                                    assertEquals(myListResponse, params.response);
                                 }
                             }
                         ]


### PR DESCRIPTION
I added an instruction to retrieve the called services information.
```
newParams.response = that.reader.smd.services[that.name];
```